### PR TITLE
lmi: overlay: Adapt for statusbar height (from raphael)

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -17,14 +17,24 @@
 -->
 <resources>
     <!-- Default radius of the software rounded corners. -->
-    <dimen name="rounded_corner_radius">144px</dimen>
+    <dimen name="rounded_corner_radius">103px</dimen>
 
     <!-- Height of the status bar -->
     <dimen name="status_bar_height_default">35dp</dimen>
+
+    <!-- Height of the status bar in portrait. -->
+    <dimen name="status_bar_height_portrait">35dp</dimen>
+
+    <!-- Height of the status bar in landscape. -->
+    <dimen name="status_bar_height_landscape">28dp</dimen>
+
+    <!-- The padding on the side of the navigation bar. Must be greater than or equal to
+         navigation_extra_key_width -->
+    <dimen name="navigation_side_padding">85dp</dimen>
 
     <!-- Default adjustment for the software rounded corners since corners are not perfectly
         round. This value is used when retrieving the "radius" of the rounded corner in cases
         where the exact bezier curve cannot be retrieved.  This value will be subtracted from
         rounded_corner_radius to more accurately provide a "radius" for the rounded corner. -->
-    <dimen name="rounded_corner_radius_adjustment">40px</dimen>
+    <dimen name="rounded_corner_radius_adjustment">19px</dimen>
 </resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -17,19 +17,16 @@
 -->
 <resources>
     <!-- the padding on the start of the statusbar -->
-    <dimen name="status_bar_padding_start">10dp</dimen>
+    <dimen name="status_bar_padding_start">16dp</dimen>
 
     <!-- the padding on the end of the statusbar -->
-    <dimen name="status_bar_padding_end">10dp</dimen>
+    <dimen name="status_bar_padding_end">5dp</dimen>
 
-    <!-- Margin on the right side of the system icon group on Keyguard. -->
-    <dimen name="system_icons_keyguard_padding_end">8dp</dimen>
+    <!-- Height of the status bar header bar when on Keyguard -->
+    <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height</dimen>
 
-    <!-- the padding of the rounded corner -->
-    <dimen name="rounded_corner_content_padding">8dp</dimen>
-
-    <!--  Allow CornerHandleView and PathSpecCornerPathRenderer to decouple from corner-radius -->
-    <dimen name="config_rounded_mask_size">122px</dimen>
+    <!-- Margin on the left side of the carrier text on Keyguard -->
+    <dimen name="keyguard_carrier_text_margin">25dp</dimen>
     
     <!-- With the large clock, move up slightly from the center -->
     <dimen name="keyguard_large_clock_top_margin">-152dp</dimen>


### PR DESCRIPTION
It looks great on cezanne (Redmi K30 Ultra) on June-build PixelExperience. Maybe it is also suitable for lmi.